### PR TITLE
feat: アカウント削除機能を追加

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,0 +1,12 @@
+class AccountsController < ApplicationController
+  def destroy
+    if current_user.guest?
+      redirect_to settings_path, alert: "ゲストアカウントは削除できません"
+      return
+    end
+
+    current_user.destroy!
+    reset_session
+    redirect_to root_path, notice: "アカウントを削除しました"
+  end
+end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,0 +1,4 @@
+class SettingsController < ApplicationController
+  def show
+  end
+end

--- a/app/javascript/controllers/confirm_modal_controller.js
+++ b/app/javascript/controllers/confirm_modal_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["modal", "input", "submit"]
+  static values = { keyword: String }
+
+  open() {
+    this.modalTarget.classList.remove("hidden")
+    document.body.style.overflow = "hidden"
+  }
+
+  close() {
+    this.modalTarget.classList.add("hidden")
+    document.body.style.overflow = ""
+    this.inputTarget.value = ""
+    this.submitTarget.disabled = true
+  }
+
+  verify(event) {
+    if (event.type === "keydown" && event.key === "Enter") {
+      event.preventDefault()
+      return
+    }
+    this.submitTarget.disabled = this.inputTarget.value !== this.keywordValue
+  }
+
+  backdropClose(event) {
+    if (event.target === this.modalTarget) {
+      this.close()
+    }
+  }
+
+  closeOnEscape(event) {
+    if (event.key === "Escape" && !this.modalTarget.classList.contains("hidden")) {
+      this.close()
+    }
+  }
+}

--- a/app/javascript/controllers/confirm_modal_controller.js
+++ b/app/javascript/controllers/confirm_modal_controller.js
@@ -4,6 +4,10 @@ export default class extends Controller {
   static targets = ["modal", "input", "submit"]
   static values = { keyword: String }
 
+  disconnect() {
+    document.body.style.overflow = ""
+  }
+
   open() {
     this.modalTarget.classList.remove("hidden")
     document.body.style.overflow = "hidden"

--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["menu"]
+
+  toggle() {
+    this.menuTarget.classList.toggle("hidden")
+  }
+
+  close(event) {
+    if (!this.element.contains(event.target)) {
+      this.menuTarget.classList.add("hidden")
+    }
+  }
+}

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -1,0 +1,59 @@
+<div class="max-w-lg mx-auto">
+  <h1 class="text-2xl font-bold text-gray-900 mb-6">設定</h1>
+
+  <div class="bg-white rounded-xl shadow-sm p-6">
+    <h2 class="text-lg font-bold text-gray-900 mb-4">アカウント情報</h2>
+    <dl class="space-y-3 text-sm">
+      <div class="flex justify-between">
+        <dt class="text-gray-500 shrink-0">名前</dt>
+        <dd class="text-gray-900 break-all text-right"><%= current_user.display_name %></dd>
+      </div>
+      <div class="flex justify-between">
+        <dt class="text-gray-500 shrink-0 mr-4">メールアドレス</dt>
+        <dd class="text-gray-900 break-all text-right"><%= current_user.email %></dd>
+      </div>
+    </dl>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm p-6 mt-6">
+    <h2 class="text-lg font-bold text-red-600 mb-2">アカウント削除</h2>
+    <% if current_user.guest? %>
+      <p class="text-sm text-gray-500 mb-4">ゲストアカウントは削除できません。ゲストのデータはログアウト時に自動で破棄されます。</p>
+      <div class="text-right">
+        <button type="button" disabled class="bg-gray-300 text-white px-4 py-2 rounded-lg text-sm font-medium cursor-not-allowed">アカウントを削除する</button>
+      </div>
+    <% else %>
+      <p class="text-sm text-gray-500 mb-4">アカウントを削除すると、登録した原材料・商品などすべてのデータが完全に削除されます。この操作は取り消せません。</p>
+      <div data-controller="confirm-modal" data-confirm-modal-keyword-value="削除">
+        <div class="text-right">
+          <button type="button" data-action="confirm-modal#open"
+            class="bg-red-600 text-white px-4 py-2 rounded-lg hover:bg-red-700 text-sm font-medium cursor-pointer">
+            アカウントを削除する
+          </button>
+        </div>
+
+        <div data-confirm-modal-target="modal" data-action="click->confirm-modal#backdropClose keydown@window->confirm-modal#closeOnEscape"
+          class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div class="bg-white rounded-xl shadow-lg p-6 w-full max-w-md mx-4">
+            <h3 class="text-lg font-bold text-gray-900 mb-2">アカウント削除の確認</h3>
+            <p class="text-sm text-gray-600 mb-4">この操作は取り消せません。すべてのデータが完全に削除されます。</p>
+            <p class="text-sm text-gray-700 mb-2">確認のため「<span class="font-bold text-red-600">削除</span>」と入力してください。</p>
+            <input type="text" data-confirm-modal-target="input" data-action="input->confirm-modal#verify keydown.enter->confirm-modal#verify"
+              class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm mb-4 focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-red-500"
+              placeholder="削除" autocomplete="off">
+            <div class="flex justify-end gap-3">
+              <button type="button" data-action="confirm-modal#close"
+                class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 cursor-pointer">
+                キャンセル
+              </button>
+              <%= button_to "アカウントを削除する", account_path, method: :delete,
+                  class: "bg-red-600 text-white px-4 py-2 rounded-lg hover:bg-red-700 text-sm font-medium disabled:bg-gray-300 disabled:cursor-not-allowed cursor-pointer",
+                  disabled: true,
+                  data: { confirm_modal_target: "submit" } %>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,8 +7,19 @@
         <nav class="hidden md:flex items-center space-x-6">
           <%= link_to "原材料", materials_path, class: "text-gray-600 hover:text-gray-900 text-sm" %>
           <%= link_to "商品", products_path, class: "text-gray-600 hover:text-gray-900 text-sm" %>
-          <%= button_to "ログアウト", destroy_user_session_path, method: :delete,
-              class: "text-gray-600 hover:text-gray-900 text-sm cursor-pointer" %>
+          <div class="relative" data-controller="dropdown" data-action="click@window->dropdown#close">
+            <button type="button" data-action="dropdown#toggle" class="text-gray-600 hover:text-gray-900 cursor-pointer">
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+              </svg>
+            </button>
+            <div class="hidden absolute right-0 mt-2 w-40 bg-white rounded-lg shadow-lg border border-gray-100 py-1 z-50" data-dropdown-target="menu">
+              <%= link_to "設定", settings_path, class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50" %>
+              <%= button_to "ログアウト", destroy_user_session_path, method: :delete,
+                  class: "block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 cursor-pointer" %>
+            </div>
+          </div>
         </nav>
 
         <button class="md:hidden text-gray-600 cursor-pointer" data-action="menu#toggle">
@@ -22,6 +33,7 @@
         <nav class="hidden md:hidden absolute top-16 left-0 right-0 bg-white border-b border-gray-100 px-4 py-3 space-y-3 z-50" data-menu-target="menu">
           <%= link_to "原材料", materials_path, class: "block text-gray-600 hover:text-gray-900 text-sm" %>
           <%= link_to "商品", products_path, class: "block text-gray-600 hover:text-gray-900 text-sm" %>
+          <%= link_to "設定", settings_path, class: "block text-gray-600 hover:text-gray-900 text-sm" %>
           <%= button_to "ログアウト", destroy_user_session_path, method: :delete,
               class: "block text-gray-600 hover:text-gray-900 text-sm text-left w-full cursor-pointer" %>
         </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
     post "users/guest_sign_in", to: "users/guest_sessions#create", as: :guest_sign_in
   end
 
+  resource :settings, only: %i[show]
+  resource :account, only: %i[destroy]
   resources :materials, only: %i[index new create edit update destroy]
   resources :products, only: %i[index new create edit update destroy]
 

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe "Accounts", type: :request do
+  let(:user) { create(:user, provider: "google_oauth2", uid: "123", email: "test@example.com") }
+
+  describe "DELETE /account" do
+    context "ログイン時" do
+      before { sign_in user }
+
+      it "アカウントが削除される" do
+        expect {
+          delete account_path
+        }.to change(User, :count).by(-1)
+      end
+
+      it "紐づく原材料が削除される" do
+        create(:material, user: user)
+        expect {
+          delete account_path
+        }.to change(Material, :count).by(-1)
+      end
+
+      it "紐づく商品が削除される" do
+        create(:product, user: user)
+        expect {
+          delete account_path
+        }.to change(Product, :count).by(-1)
+      end
+
+      it "紐づく商品原材料が削除される" do
+        product = create(:product, user: user)
+        material = create(:material, user: user)
+        create(:product_material, product: product, material: material, quantity: 100)
+        expect {
+          delete account_path
+        }.to change(ProductMaterial, :count).by(-1)
+      end
+
+      it "紐づく原材料アレルゲンが削除される" do
+        material = create(:material, user: user)
+        allergen = create(:allergen, :required, name: "卵")
+        material.allergens << allergen
+        expect {
+          delete account_path
+        }.to change(MaterialAllergen, :count).by(-1)
+      end
+
+      it "削除後にトップページにリダイレクトされる" do
+        delete account_path
+        expect(response).to redirect_to(root_path)
+        expect(flash[:notice]).to eq("アカウントを削除しました")
+      end
+    end
+
+    context "ゲストログイン時" do
+      let(:guest) { create(:user, provider: "guest", uid: "guest_123", email: "guest@example.com") }
+
+      before { sign_in guest }
+
+      it "アカウントが削除されない" do
+        expect {
+          delete account_path
+        }.not_to change(User, :count)
+      end
+
+      it "設定画面にリダイレクトされる" do
+        delete account_path
+        expect(response).to redirect_to(settings_path)
+        expect(flash[:alert]).to eq("ゲストアカウントは削除できません")
+      end
+    end
+
+    context "未ログイン時" do
+      it "リダイレクトされる" do
+        delete account_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -23,6 +23,17 @@ RSpec.describe "Settings", type: :request do
       end
     end
 
+    context "ゲストユーザーログイン時" do
+      let(:guest) { create(:user, provider: "guest", uid: "guest_123") }
+
+      before { sign_in guest }
+
+      it "アカウント削除不可のメッセージが表示される" do
+        get settings_path
+        expect(response.body).to include("ゲストアカウントは削除できません")
+      end
+    end
+
     context "未ログイン時" do
       it "リダイレクトされる" do
         get settings_path

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe "Settings", type: :request do
+  let(:user) { create(:user, provider: "google_oauth2", uid: "123", email: "test@example.com") }
+
+  describe "GET /settings" do
+    context "ログイン時" do
+      before { sign_in user }
+
+      it "設定画面が表示される" do
+        get settings_path
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "アカウント情報が表示される" do
+        get settings_path
+        expect(response.body).to include(user.email)
+      end
+
+      it "アカウント削除ボタンが表示される" do
+        get settings_path
+        expect(response.body).to include("アカウントを削除する")
+      end
+    end
+
+    context "未ログイン時" do
+      it "リダイレクトされる" do
+        get settings_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 背景
ユーザーが自分のアカウントを削除できる機能がなかった。
アカウント削除時の誤操作を防ぐため、「削除」とテキスト入力して確認するカスタムモーダルを実装した。

## やったこと
- 設定画面（`/settings`）を新規作成し、アカウント情報の表示とアカウント削除セクションを配置
- アカウント削除コントローラー（`AccountsController#destroy`）を追加
- 確認モーダル用の Stimulus コントローラー（`confirm-modal`）を作成
  - 「削除」と入力するまで削除ボタンを無効化
  - Escape キー・背景クリック・キャンセルボタンでモーダルを閉じる
  - モーダル表示中は背景スクロールを防止
  - Enter キーによる誤送信を防止
- ヘッダーに歯車アイコンのドロップダウンメニューを追加し、設定画面への導線を設置
- ゲストユーザーはアカウント削除不可（ボタン disabled + サーバーサイドでもガード）

## 確認方法
- [x] 設定画面で「アカウントを削除する」クリック → モーダル表示
- [x] 「削除」以外の入力では削除ボタンが disabled
- [x] 「削除」と入力すると削除ボタンが有効化
- [x] キャンセル・Escape・背景クリックでモーダルが閉じる
- [x] Enter キーで誤送信されないこと
- [x] ゲストユーザーは削除ボタンが disabled のまま
- [x] `bundle exec rspec` が全テスト通過

## 関連Issue
Closes #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings page showing account info; header now has a dropdown with Settings and Logout.
  * Account deletion flow with confirmation modal; guest accounts cannot be deleted and are blocked with a message.
* **Tests**
  * Request specs covering Settings page access and account deletion behaviors (signed-in, guest, unauthenticated).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->