### PR TITLE
feat: 栄養成分の自動計算機能を追加

### DIFF
--- a/app/controllers/materials_controller.rb
+++ b/app/controllers/materials_controller.rb
@@ -50,6 +50,7 @@ class MaterialsController < ApplicationController
   end
 
   def material_params
-    params.require(:material).permit(:name, :display_name, :purchase_price, :purchase_quantity, :unit, :additive, allergen_ids: [])
+    params.require(:material).permit(:name, :display_name, :purchase_price, :purchase_quantity, :unit, :additive,
+                                     :energy, :protein, :fat, :carbohydrate, :salt, allergen_ids: [])
   end
 end

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -4,7 +4,12 @@ module ProductsHelper
       label = "#{m.name}（#{m.unit} / ¥#{m.unit_price}）"
       data = {
         "data-unit-price" => m.unit_price.to_f,
-        "data-allergens" => m.allergens.map { |a| { name: a.name, required: a.required? } }.to_json
+        "data-allergens" => m.allergens.map { |a| { name: a.name, required: a.required? } }.to_json,
+        "data-energy" => m.energy&.to_f || "",
+        "data-protein" => m.protein&.to_f || "",
+        "data-fat" => m.fat&.to_f || "",
+        "data-carbohydrate" => m.carbohydrate&.to_f || "",
+        "data-salt" => m.salt&.to_f || ""
       }
       [ label, m.id, data ]
     end

--- a/app/javascript/controllers/nutrition_calculator_controller.js
+++ b/app/javascript/controllers/nutrition_calculator_controller.js
@@ -1,5 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
+const NUTRITION_FIELDS = ["energy", "protein", "fat", "carbohydrate", "salt"]
+
 export default class extends Controller {
   static targets = [
     "row", "destroy", "materialSelect", "quantity",
@@ -24,8 +26,7 @@ export default class extends Controller {
   }
 
   collectNutrition() {
-    const fields = ["energy", "protein", "fat", "carbohydrate", "salt"]
-    const totals = { energy: 0, protein: 0, fat: 0, carbohydrate: 0, salt: 0 }
+    const totals = Object.fromEntries(NUTRITION_FIELDS.map(f => [f, 0]))
     let totalWeight = 0
     let hasNutrition = false
 
@@ -38,7 +39,7 @@ export default class extends Controller {
       const quantity = parseFloat(this.quantityTargets[index]?.value) || 0
       totalWeight += quantity
 
-      fields.forEach(field => {
+      NUTRITION_FIELDS.forEach(field => {
         const raw = option.dataset[field]
         if (raw === "") return
         const value = parseFloat(raw) || 0
@@ -66,8 +67,7 @@ export default class extends Controller {
       this.carbohydratePer100gTarget.textContent = this.formatValue(totals.carbohydrate * 100 / totalWeight, "g")
       this.saltPer100gTarget.textContent = this.formatValue(totals.salt * 100 / totalWeight, "g")
     } else {
-      const fields = ["energyPer100g", "proteinPer100g", "fatPer100g", "carbohydratePer100g", "saltPer100g"]
-      fields.forEach(f => { this[`${f}Target`].textContent = "-" })
+      NUTRITION_FIELDS.forEach(f => { this[`${f}Per100gTarget`].textContent = "-" })
     }
 
     this.summaryTarget.classList.toggle("hidden", !hasNutrition)

--- a/app/javascript/controllers/nutrition_calculator_controller.js
+++ b/app/javascript/controllers/nutrition_calculator_controller.js
@@ -1,0 +1,91 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [
+    "row", "destroy", "materialSelect", "quantity",
+    "summary",
+    "energy", "protein", "fat", "carbohydrate", "salt",
+    "energyPer100g", "proteinPer100g", "fatPer100g", "carbohydratePer100g", "saltPer100g",
+    "perItemSection", "per100gSection", "toggleButton",
+    "emptyMessage"
+  ]
+
+  connect() {
+    this.displayMode = "perItem"
+    this.recalculate()
+  }
+
+  rowTargetConnected() { this.recalculate() }
+  rowTargetDisconnected() { this.recalculate() }
+
+  recalculate() {
+    const { totals, totalWeight, hasNutrition } = this.collectNutrition()
+    this.display(totals, totalWeight, hasNutrition)
+  }
+
+  collectNutrition() {
+    const fields = ["energy", "protein", "fat", "carbohydrate", "salt"]
+    const totals = { energy: 0, protein: 0, fat: 0, carbohydrate: 0, salt: 0 }
+    let totalWeight = 0
+    let hasNutrition = false
+
+    this.materialSelectTargets.forEach((select, index) => {
+      if (this.destroyTargets[index]?.value === "true") return
+
+      const option = select.selectedOptions[0]
+      if (!option?.value) return
+
+      const quantity = parseFloat(this.quantityTargets[index]?.value) || 0
+      totalWeight += quantity
+
+      fields.forEach(field => {
+        const raw = option.dataset[field]
+        if (raw === "") return
+        const value = parseFloat(raw) || 0
+        hasNutrition = true
+        totals[field] += value * quantity / 100
+      })
+    })
+
+    return { totals, totalWeight, hasNutrition }
+  }
+
+  display(totals, totalWeight, hasNutrition) {
+    if (!this.hasSummaryTarget) return
+
+    this.energyTarget.textContent = this.formatValue(totals.energy, "kcal")
+    this.proteinTarget.textContent = this.formatValue(totals.protein, "g")
+    this.fatTarget.textContent = this.formatValue(totals.fat, "g")
+    this.carbohydrateTarget.textContent = this.formatValue(totals.carbohydrate, "g")
+    this.saltTarget.textContent = this.formatValue(totals.salt, "g")
+
+    if (totalWeight > 0) {
+      this.energyPer100gTarget.textContent = this.formatValue(totals.energy * 100 / totalWeight, "kcal")
+      this.proteinPer100gTarget.textContent = this.formatValue(totals.protein * 100 / totalWeight, "g")
+      this.fatPer100gTarget.textContent = this.formatValue(totals.fat * 100 / totalWeight, "g")
+      this.carbohydratePer100gTarget.textContent = this.formatValue(totals.carbohydrate * 100 / totalWeight, "g")
+      this.saltPer100gTarget.textContent = this.formatValue(totals.salt * 100 / totalWeight, "g")
+    } else {
+      const fields = ["energyPer100g", "proteinPer100g", "fatPer100g", "carbohydratePer100g", "saltPer100g"]
+      fields.forEach(f => { this[`${f}Target`].textContent = "-" })
+    }
+
+    this.summaryTarget.classList.toggle("hidden", !hasNutrition)
+    if (this.hasEmptyMessageTarget) {
+      this.emptyMessageTarget.classList.toggle("hidden", hasNutrition)
+    }
+  }
+
+  toggleDisplay() {
+    this.displayMode = this.displayMode === "perItem" ? "per100g" : "perItem"
+    this.perItemSectionTarget.classList.toggle("hidden", this.displayMode !== "perItem")
+    this.per100gSectionTarget.classList.toggle("hidden", this.displayMode !== "per100g")
+    this.toggleButtonTarget.textContent =
+      this.displayMode === "perItem" ? "100gあたりに切替" : "1個あたりに切替"
+  }
+
+  formatValue(value, unit) {
+    const rounded = Math.round(value * 10) / 10
+    return `${rounded.toFixed(1)}${unit}`
+  }
+}

--- a/app/models/concerns/cost_calculatable.rb
+++ b/app/models/concerns/cost_calculatable.rb
@@ -1,0 +1,27 @@
+module CostCalculatable
+  extend ActiveSupport::Concern
+
+  def total_cost
+    product_materials.sum(&:subtotal)
+  end
+
+  def cost_rate
+    return 0 if sales_price.blank? || sales_price.zero?
+
+    rate = (total_cost / sales_price * 100).round(1)
+    rate % 1 == 0 ? rate.to_i : rate
+  end
+
+  def gross_profit
+    return 0 if sales_price.blank?
+
+    sales_price - total_cost
+  end
+
+  def profit_rate
+    return 0 if sales_price.blank? || sales_price.zero?
+
+    rate = (gross_profit / sales_price * 100).round(1)
+    rate % 1 == 0 ? rate.to_i : rate
+  end
+end

--- a/app/models/concerns/nutrition_calculatable.rb
+++ b/app/models/concerns/nutrition_calculatable.rb
@@ -1,0 +1,64 @@
+module NutritionCalculatable
+  extend ActiveSupport::Concern
+
+  NUTRITION_SCALE = 2
+  NUTRITION_FIELDS = %i[energy protein fat carbohydrate salt].freeze
+
+  # g と ml を区別せず合算（栄養成分表示は推定値のため許容）
+  def total_weight
+    product_materials.sum { |pm| pm.quantity || 0 }
+  end
+
+  def total_energy
+    nutrition_totals[:energy]
+  end
+
+  def total_protein
+    nutrition_totals[:protein]
+  end
+
+  def total_fat
+    nutrition_totals[:fat]
+  end
+
+  def total_carbohydrate
+    nutrition_totals[:carbohydrate]
+  end
+
+  def total_salt
+    nutrition_totals[:salt]
+  end
+
+  def has_nutrition_data?
+    NUTRITION_FIELDS.any? { |f| nutrition_totals[f].positive? }
+  end
+
+  def nutrition_per_100g(field)
+    raise ArgumentError, "Invalid nutrition field: #{field}" unless NUTRITION_FIELDS.include?(field)
+
+    total = nutrition_totals[field]
+    weight = total_weight
+    return 0 if weight.zero?
+
+    (total * 100 / weight).round(1)
+  end
+
+  private
+
+  def nutrition_totals
+    @nutrition_totals ||= begin
+      result = NUTRITION_FIELDS.each_with_object({}) { |f, h| h[f] = 0.0 }
+      product_materials.each do |pm|
+        next if pm.material.blank? || pm.quantity.blank?
+
+        NUTRITION_FIELDS.each do |field|
+          value = pm.material.public_send(field)
+          next if value.nil?
+
+          result[field] += value * pm.quantity / 100
+        end
+      end
+      result.transform_values { |v| v.round(NUTRITION_SCALE) }
+    end
+  end
+end

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -12,6 +12,11 @@ class Material < ApplicationRecord
   validates :purchase_price, presence: true, numericality: { greater_than: 0 }
   validates :purchase_quantity, presence: true, numericality: { greater_than: 0 }
   validates :unit, presence: true, inclusion: { in: ALLOWED_UNITS }
+  validates :energy, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :protein, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :fat, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :carbohydrate, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :salt, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
 
   before_validation :calculate_unit_price
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,4 +1,7 @@
 class Product < ApplicationRecord
+  include NutritionCalculatable
+  include CostCalculatable
+
   CATEGORIES = %w[焼き菓子 生菓子 チョコレート パン 和菓子 アイス・冷菓 ドリンク その他].freeze
 
   belongs_to :user
@@ -18,29 +21,5 @@ class Product < ApplicationRecord
 
   def recommended_allergens
     allergens.where(required: false)
-  end
-
-  def total_cost
-    product_materials.sum(&:subtotal)
-  end
-
-  def cost_rate
-    return 0 if sales_price.blank? || sales_price.zero?
-
-    rate = (total_cost / sales_price * 100).round(1)
-    rate % 1 == 0 ? rate.to_i : rate
-  end
-
-  def gross_profit
-    return 0 if sales_price.blank?
-
-    sales_price - total_cost
-  end
-
-  def profit_rate
-    return 0 if sales_price.blank? || sales_price.zero?
-
-    rate = (gross_profit / sales_price * 100).round(1)
-    rate % 1 == 0 ? rate.to_i : rate
   end
 end

--- a/app/views/materials/_form.html.erb
+++ b/app/views/materials/_form.html.erb
@@ -55,6 +55,46 @@
   <hr class="my-6 border-gray-200">
 
   <div>
+    <span class="block text-sm font-medium text-gray-700 mb-3">栄養成分（100gあたり）</span>
+    <p class="text-xs text-gray-500 mb-3">パッケージに記載の値を入力してください（任意）</p>
+
+    <div class="grid grid-cols-2 gap-4">
+      <div>
+        <%= f.label :energy, class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.number_field :energy, step: 0.01, min: 0,
+            class: "w-full border #{error_border(f.object, :energy)} rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500" %>
+        <%= render "shared/field_errors", object: material, field: :energy %>
+      </div>
+      <div>
+        <%= f.label :protein, class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.number_field :protein, step: 0.01, min: 0,
+            class: "w-full border #{error_border(f.object, :protein)} rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500" %>
+        <%= render "shared/field_errors", object: material, field: :protein %>
+      </div>
+      <div>
+        <%= f.label :fat, class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.number_field :fat, step: 0.01, min: 0,
+            class: "w-full border #{error_border(f.object, :fat)} rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500" %>
+        <%= render "shared/field_errors", object: material, field: :fat %>
+      </div>
+      <div>
+        <%= f.label :carbohydrate, class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.number_field :carbohydrate, step: 0.01, min: 0,
+            class: "w-full border #{error_border(f.object, :carbohydrate)} rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500" %>
+        <%= render "shared/field_errors", object: material, field: :carbohydrate %>
+      </div>
+      <div>
+        <%= f.label :salt, class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.number_field :salt, step: 0.01, min: 0,
+            class: "w-full border #{error_border(f.object, :salt)} rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500" %>
+        <%= render "shared/field_errors", object: material, field: :salt %>
+      </div>
+    </div>
+  </div>
+
+  <hr class="my-6 border-gray-200">
+
+  <div>
     <span class="block text-sm font-medium text-gray-700 mb-3">アレルゲン</span>
 
     <div class="mb-3">

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: product, class: "space-y-6", data: { controller: "cost-calculator allergen-display" }) do |f| %>
+<%= form_with(model: product, class: "space-y-6", data: { controller: "cost-calculator allergen-display nutrition-calculator" }) do |f| %>
   <div>
     <%= f.label :name, class: "block text-sm font-medium text-gray-700 mb-1" %>
     <%= f.text_field :name, class: "w-full border #{error_border(f.object, :name)} rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500" %>
@@ -43,7 +43,7 @@
     </div>
 
     <div data-nested-form-target="container" class="space-y-3"
-         data-action="change->cost-calculator#recalculate input->cost-calculator#recalculate change->allergen-display#updateAllergens">
+         data-action="change->cost-calculator#recalculate input->cost-calculator#recalculate change->allergen-display#updateAllergens change->nutrition-calculator#recalculate input->nutrition-calculator#recalculate">
       <%= f.fields_for :product_materials do |pm| %>
         <%= render "product_material_fields", f: pm, materials: @materials %>
       <% end %>
@@ -57,6 +57,7 @@
   </div>
 
   <%= render "cost_summary", product: product %>
+  <%= render "nutrition_summary", product: product %>
   <%= render "allergen_summary", product: product %>
 
   <div>

--- a/app/views/products/_nutrition_summary.html.erb
+++ b/app/views/products/_nutrition_summary.html.erb
@@ -1,0 +1,70 @@
+<div class="bg-white rounded-xl shadow-sm p-6 mb-6">
+  <div class="flex justify-between items-center mb-3">
+    <p class="text-sm font-medium text-gray-700">栄養成分表示</p>
+    <button type="button"
+      data-nutrition-calculator-target="toggleButton"
+      data-action="nutrition-calculator#toggleDisplay"
+      class="text-orange-500 hover:text-orange-700 text-sm font-medium cursor-pointer">
+      100gあたりに切替
+    </button>
+  </div>
+
+  <div data-nutrition-calculator-target="summary" class="<%= 'hidden' unless product.has_nutrition_data? %>">
+    <div data-nutrition-calculator-target="perItemSection">
+      <p class="text-xs text-gray-500 mb-2">1個あたり</p>
+      <div class="grid grid-cols-5 gap-2">
+        <div class="bg-gray-50 rounded-lg p-3 text-center">
+          <p class="text-xs text-gray-500 mb-1">エネルギー</p>
+          <p class="text-sm font-bold text-gray-900" data-nutrition-calculator-target="energy"><%= product.total_energy.round(1) %>kcal</p>
+        </div>
+        <div class="bg-gray-50 rounded-lg p-3 text-center">
+          <p class="text-xs text-gray-500 mb-1">たんぱく質</p>
+          <p class="text-sm font-bold text-gray-900" data-nutrition-calculator-target="protein"><%= product.total_protein.round(1) %>g</p>
+        </div>
+        <div class="bg-gray-50 rounded-lg p-3 text-center">
+          <p class="text-xs text-gray-500 mb-1">脂質</p>
+          <p class="text-sm font-bold text-gray-900" data-nutrition-calculator-target="fat"><%= product.total_fat.round(1) %>g</p>
+        </div>
+        <div class="bg-gray-50 rounded-lg p-3 text-center">
+          <p class="text-xs text-gray-500 mb-1">炭水化物</p>
+          <p class="text-sm font-bold text-gray-900" data-nutrition-calculator-target="carbohydrate"><%= product.total_carbohydrate.round(1) %>g</p>
+        </div>
+        <div class="bg-gray-50 rounded-lg p-3 text-center">
+          <p class="text-xs text-gray-500 mb-1">食塩相当量</p>
+          <p class="text-sm font-bold text-gray-900" data-nutrition-calculator-target="salt"><%= product.total_salt.round(1) %>g</p>
+        </div>
+      </div>
+    </div>
+
+    <div data-nutrition-calculator-target="per100gSection" class="hidden">
+      <p class="text-xs text-gray-500 mb-2">100gあたり</p>
+      <div class="grid grid-cols-5 gap-2">
+        <div class="bg-gray-50 rounded-lg p-3 text-center">
+          <p class="text-xs text-gray-500 mb-1">エネルギー</p>
+          <p class="text-sm font-bold text-gray-900" data-nutrition-calculator-target="energyPer100g"><%= product.nutrition_per_100g(:energy) %>kcal</p>
+        </div>
+        <div class="bg-gray-50 rounded-lg p-3 text-center">
+          <p class="text-xs text-gray-500 mb-1">たんぱく質</p>
+          <p class="text-sm font-bold text-gray-900" data-nutrition-calculator-target="proteinPer100g"><%= product.nutrition_per_100g(:protein) %>g</p>
+        </div>
+        <div class="bg-gray-50 rounded-lg p-3 text-center">
+          <p class="text-xs text-gray-500 mb-1">脂質</p>
+          <p class="text-sm font-bold text-gray-900" data-nutrition-calculator-target="fatPer100g"><%= product.nutrition_per_100g(:fat) %>g</p>
+        </div>
+        <div class="bg-gray-50 rounded-lg p-3 text-center">
+          <p class="text-xs text-gray-500 mb-1">炭水化物</p>
+          <p class="text-sm font-bold text-gray-900" data-nutrition-calculator-target="carbohydratePer100g"><%= product.nutrition_per_100g(:carbohydrate) %>g</p>
+        </div>
+        <div class="bg-gray-50 rounded-lg p-3 text-center">
+          <p class="text-xs text-gray-500 mb-1">食塩相当量</p>
+          <p class="text-sm font-bold text-gray-900" data-nutrition-calculator-target="saltPer100g"><%= product.nutrition_per_100g(:salt) %>g</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <p data-nutrition-calculator-target="emptyMessage"
+     class="text-sm text-gray-400 <%= 'hidden' if product.has_nutrition_data? %>">
+    栄養成分データがありません
+  </p>
+</div>

--- a/app/views/products/_product_material_fields.html.erb
+++ b/app/views/products/_product_material_fields.html.erb
@@ -1,7 +1,7 @@
-<div class="nested-fields relative border border-gray-200 rounded-lg p-3 md:border-0 md:p-0" data-cost-calculator-target="row" data-allergen-display-target="row">
-  <%= f.hidden_field :_destroy, data: { cost_calculator_target: "destroy", allergen_display_target: "destroy" } %>
+<div class="nested-fields relative border border-gray-200 rounded-lg p-3 md:border-0 md:p-0" data-cost-calculator-target="row" data-allergen-display-target="row" data-nutrition-calculator-target="row">
+  <%= f.hidden_field :_destroy, data: { cost_calculator_target: "destroy", allergen_display_target: "destroy", nutrition_calculator_target: "destroy" } %>
   <div class="flex justify-end md:hidden mb-1">
-    <button type="button" data-action="nested-form#remove click->cost-calculator#recalculate click->allergen-display#updateAllergens" class="text-sm text-red-500 hover:text-red-700 cursor-pointer">削除</button>
+    <button type="button" data-action="nested-form#remove click->cost-calculator#recalculate click->allergen-display#updateAllergens click->nutrition-calculator#recalculate" class="text-sm text-red-500 hover:text-red-700 cursor-pointer">削除</button>
   </div>
   <div class="space-y-2 md:space-y-0 md:flex md:items-center md:gap-3">
     <div class="flex items-end gap-2 md:contents">
@@ -10,13 +10,13 @@
         <%= f.select :material_id,
             options_for_select(material_select_options(materials), f.object.material_id),
             { include_blank: "原材料を選択" },
-            data: { cost_calculator_target: "materialSelect", allergen_display_target: "materialSelect" },
+            data: { cost_calculator_target: "materialSelect", allergen_display_target: "materialSelect", nutrition_calculator_target: "materialSelect" },
             class: "w-full border #{error_border(f.object, :material)} rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500" %>
       </div>
       <div class="w-24 md:flex-none">
         <span class="block text-xs text-gray-500 mb-1 md:hidden">使用量</span>
         <%= f.number_field :quantity, step: 0.01, min: 0, placeholder: "使用量",
-            data: { cost_calculator_target: "quantity" },
+            data: { cost_calculator_target: "quantity", nutrition_calculator_target: "quantity" },
             class: "w-full border #{error_border(f.object, :quantity)} rounded-lg px-3 py-2 text-sm placeholder-gray-300 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500" %>
       </div>
     </div>
@@ -32,7 +32,7 @@
       </div>
     </div>
     <div class="hidden md:flex items-center">
-      <button type="button" data-action="nested-form#remove click->cost-calculator#recalculate click->allergen-display#updateAllergens" class="text-gray-400 hover:text-red-500 cursor-pointer" title="削除">
+      <button type="button" data-action="nested-form#remove click->cost-calculator#recalculate click->allergen-display#updateAllergens click->nutrition-calculator#recalculate" class="text-gray-400 hover:text-red-500 cursor-pointer" title="削除">
         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
         </svg>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,6 +12,11 @@ ja:
         unit: 単位
         unit_price: 単価
         additive: 添加物
+        energy: エネルギー（kcal）
+        protein: たんぱく質（g）
+        fat: 脂質（g）
+        carbohydrate: 炭水化物（g）
+        salt: 食塩相当量（g）
       product:
         name: 商品名
         category: カテゴリ

--- a/db/migrate/20260327140955_add_nutrition_to_materials.rb
+++ b/db/migrate/20260327140955_add_nutrition_to_materials.rb
@@ -1,0 +1,9 @@
+class AddNutritionToMaterials < ActiveRecord::Migration[8.0]
+  def change
+    add_column :materials, :energy, :decimal, precision: 10, scale: 2
+    add_column :materials, :protein, :decimal, precision: 10, scale: 2
+    add_column :materials, :fat, :decimal, precision: 10, scale: 2
+    add_column :materials, :carbohydrate, :decimal, precision: 10, scale: 2
+    add_column :materials, :salt, :decimal, precision: 10, scale: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_17_103738) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_27_140955) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -44,6 +44,11 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_17_103738) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.decimal "energy", precision: 10, scale: 2
+    t.decimal "protein", precision: 10, scale: 2
+    t.decimal "fat", precision: 10, scale: 2
+    t.decimal "carbohydrate", precision: 10, scale: 2
+    t.decimal "salt", precision: 10, scale: 2
     t.index ["user_id"], name: "index_materials_on_user_id"
   end
 

--- a/spec/factories/materials.rb
+++ b/spec/factories/materials.rb
@@ -6,5 +6,13 @@ FactoryBot.define do
     unit { "g" }
     additive { false }
     user
+
+    trait :with_nutrition do
+      energy { 349 }
+      protein { 8.3 }
+      fat { 1.5 }
+      carbohydrate { 75.8 }
+      salt { 0 }
+    end
   end
 end

--- a/spec/models/material_spec.rb
+++ b/spec/models/material_spec.rb
@@ -91,6 +91,25 @@ RSpec.describe Material, type: :model do
     end
   end
 
+  describe "栄養成分バリデーション" do
+    it "栄養成分がnilでも有効" do
+      material = build(:material, energy: nil, protein: nil, fat: nil, carbohydrate: nil, salt: nil)
+      expect(material).to be_valid
+    end
+
+    it "栄養成分が0でも有効" do
+      material = build(:material, energy: 0, protein: 0, fat: 0, carbohydrate: 0, salt: 0)
+      expect(material).to be_valid
+    end
+
+    %i[energy protein fat carbohydrate salt].each do |field|
+      it "#{field}が負なら無効" do
+        material = build(:material, field => -1)
+        expect(material).to be_invalid
+      end
+    end
+  end
+
   describe "アソシエーション" do
     it "ユーザーが削除されると原材料も削除される" do
       material = create(:material)

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -115,6 +115,101 @@ RSpec.describe Product, type: :model do
     end
   end
 
+  describe "栄養成分計算" do
+    let(:product) { create(:product, sales_price: 500) }
+    let(:material_a) do
+      create(:material, :with_nutrition, user: product.user,
+        purchase_price: 1000, purchase_quantity: 500, unit: "g",
+        energy: 349, protein: 8.3, fat: 1.5, carbohydrate: 75.8, salt: 0)
+    end
+    let(:material_b) do
+      create(:material, :with_nutrition, user: product.user,
+        purchase_price: 300, purchase_quantity: 1000, unit: "g",
+        energy: 720, protein: 0.5, fat: 81.0, carbohydrate: 0.2, salt: 1.9)
+    end
+
+    before do
+      create(:product_material, product: product, material: material_a, quantity: 200)
+      create(:product_material, product: product, material: material_b, quantity: 100)
+    end
+
+    it "エネルギー合計を計算できる" do
+      # 349*200/100 + 720*100/100 = 698 + 720 = 1418
+      expect(product.total_energy).to eq(1418.0)
+    end
+
+    it "たんぱく質合計を計算できる" do
+      # 8.3*200/100 + 0.5*100/100 = 16.6 + 0.5 = 17.1
+      expect(product.total_protein).to eq(17.1)
+    end
+
+    it "脂質合計を計算できる" do
+      # 1.5*200/100 + 81.0*100/100 = 3.0 + 81.0 = 84.0
+      expect(product.total_fat).to eq(84.0)
+    end
+
+    it "炭水化物合計を計算できる" do
+      # 75.8*200/100 + 0.2*100/100 = 151.6 + 0.2 = 151.8
+      expect(product.total_carbohydrate).to eq(151.8)
+    end
+
+    it "食塩相当量合計を計算できる" do
+      # 0*200/100 + 1.9*100/100 = 0 + 1.9 = 1.9
+      expect(product.total_salt).to eq(1.9)
+    end
+
+    it "総重量を計算できる" do
+      expect(product.total_weight).to eq(300)
+    end
+
+    it "100gあたりの栄養成分を計算できる" do
+      # 1418*100/300 = 472.7
+      expect(product.nutrition_per_100g(:energy)).to eq(472.7)
+    end
+
+    it "100gあたりの食塩相当量を計算できる" do
+      # 1.9*100/300 = 0.6
+      expect(product.nutrition_per_100g(:salt)).to eq(0.6)
+    end
+
+    it "不正なフィールド名でArgumentErrorが発生する" do
+      expect { product.nutrition_per_100g(:invalid) }.to raise_error(ArgumentError)
+    end
+
+    it "栄養データがあればhas_nutrition_data?がtrueを返す" do
+      expect(product.has_nutrition_data?).to be true
+    end
+
+    context "原材料が0件の場合" do
+      let(:empty_product) { create(:product) }
+
+      it "栄養成分合計が0になる" do
+        expect(empty_product.total_energy).to eq(0)
+      end
+
+      it "100gあたりが0になる" do
+        expect(empty_product.nutrition_per_100g(:energy)).to eq(0)
+      end
+    end
+
+    context "原材料に栄養データがない場合" do
+      let(:no_nutrition_product) { create(:product) }
+
+      before do
+        material = create(:material, user: no_nutrition_product.user)
+        create(:product_material, product: no_nutrition_product, material: material, quantity: 100)
+      end
+
+      it "栄養成分合計が0になる" do
+        expect(no_nutrition_product.total_energy).to eq(0)
+      end
+
+      it "has_nutrition_data?がfalseを返す" do
+        expect(no_nutrition_product.has_nutrition_data?).to be false
+      end
+    end
+  end
+
   describe "原価計算" do
     let(:product) { create(:product, sales_price: 500) }
     let(:material_a) { create(:material, user: product.user, purchase_price: 1000, purchase_quantity: 500, unit: "g") }


### PR DESCRIPTION
## 背景
商品に使用する原材料の栄養成分（100gあたり）から、商品1個あたり・100gあたりの栄養成分を自動計算する機能がなかった。
食品表示法で義務付けられている栄養成分表示（エネルギー、たんぱく質、脂質、炭水化物、食塩相当量）の作成を支援するために実装した。

## やったこと
- materialsテーブルにenergy・protein・fat・carbohydrate・saltカラム（decimal）を追加
- 原材料フォームに栄養成分入力欄（100gあたり）を追加
- 栄養成分計算ロジックをNutritionCalculatable concernに実装（キャッシュ付き1回ループで全フィールドを計算）
- 原価計算ロジックをCostCalculatable concernに分離し、Productモデルをincludeするだけの構成に整理
- Stimulusコントローラー（nutrition-calculator）で原材料の選択・使用量変更に連動したリアルタイム計算
- 1個あたり / 100gあたりの切替表示に対応
- helperでnilと0を区別してdata属性に出力（未入力と値0の区別）
- public_sendのフィールド名をNUTRITION_FIELDS定数で制限
- サーバー/クライアント間の丸め・表示桁数・表示判定ロジックを統一

## 確認方法
- [x] 原材料フォームで栄養成分を入力・保存できること
- [x] 商品フォームで原材料選択・使用量変更に連動して栄養成分がリアルタイム計算されること
- [x] 1個あたり / 100gあたりの切替が動作すること
- [x] 栄養データのない原材料のみの場合「栄養成分データがありません」と表示されること
- [x] `bundle exec rspec` 全テスト通過（151 examples, 0 failures）
- [x] `bundle exec rubocop` オフェンスなし

## 関連Issue
Closes #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nutritional fields (energy, protein, fat, carbohydrate, salt) added to materials and material forms.
  * Product forms now auto-calculate and display total nutrition from selected ingredients with a toggle for per-item / per-100g views.
  * Inline validation prevents negative nutrition values and shows field-specific errors.
  * Japanese labels added for nutrition fields.
* **Tests**
  * Model and calculation tests added for nutrition behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->