### PR TITLE
feat: 原材料・商品一覧にページネーションを追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,3 +34,6 @@ RSpec/MultipleExpectations:
 
 RSpec/ExampleLength:
   Max: 10
+
+FactoryBot/ExcessiveCreateList:
+  MaxAmount: 25

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,8 @@ gem "devise"
 gem "devise-i18n"
 gem "omniauth-google-oauth2"
 gem "omniauth-rails_csrf_protection"
+# Pagination [https://github.com/ddnexus/pagy]
+gem "pagy"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,6 +237,10 @@ GEM
       omniauth (~> 2.0)
     orm_adapter (0.5.0)
     ostruct (0.6.3)
+    pagy (43.5.0)
+      json
+      uri
+      yaml
     parallel (1.27.0)
     parser (3.3.10.2)
       ast (~> 2.4.1)
@@ -438,6 +442,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    yaml (0.4.0)
     zeitwerk (2.7.5)
 
 PLATFORMS
@@ -461,6 +466,7 @@ DEPENDENCIES
   kamal
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
+  pagy
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -8,3 +8,44 @@
  *
  * Consider organizing styles into separate files for maintainability.
  */
+
+/* Pagy pagination */
+.pagy {
+  display: flex;
+  justify-content: center;
+  gap: 0.25rem;
+  margin-top: 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.pagy a {
+  display: block;
+  padding: 0.375rem 0.75rem;
+  border-radius: 0.5rem;
+  color: #374151;
+  background-color: #f3f4f6;
+  text-decoration: none;
+}
+
+.pagy a[href]:hover {
+  background-color: #fed7aa;
+  color: #c2410c;
+}
+
+.pagy a[aria-current="page"] {
+  background-color: #f97316;
+  color: #fff;
+}
+
+.pagy a:not([href]) {
+  cursor: default;
+}
+
+.pagy a[role="link"]:not([aria-current]) {
+  opacity: 0.5;
+}
+
+.pagy a[role="separator"] {
+  background-color: transparent;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,8 @@
 class ApplicationController < ActionController::Base
+  include Pagy::Method
+
+  rescue_from Pagy::RangeError, with: :redirect_to_first_page
+
   before_action :authenticate_user!
 
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
@@ -10,5 +14,10 @@ class ApplicationController < ActionController::Base
     unless user_signed_in?
       redirect_to root_path, alert: "ログインしてください"
     end
+  end
+
+  def redirect_to_first_page
+    query = request.query_parameters.except("page")
+    redirect_to query.empty? ? request.path : "#{request.path}?#{query.to_query}"
   end
 end

--- a/app/controllers/materials_controller.rb
+++ b/app/controllers/materials_controller.rb
@@ -1,6 +1,6 @@
 class MaterialsController < ApplicationController
   def index
-    @materials = current_user.materials.includes(:allergens).order(created_at: :desc)
+    @pagy, @materials = pagy(current_user.materials.includes(:allergens).order(created_at: :desc))
   end
 
   def new

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,6 @@
 class ProductsController < ApplicationController
   def index
-    @products = current_user.products.includes(:allergens, product_materials: :material).order(created_at: :desc)
+    @pagy, @products = pagy(current_user.products.includes(:allergens, product_materials: :material).order(created_at: :desc))
   end
 
   def new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def pagy_info_text(pagy)
+    "全#{pagy.count}件中 #{pagy.from}〜#{pagy.to}件を表示"
+  end
 end

--- a/app/views/materials/index.html.erb
+++ b/app/views/materials/index.html.erb
@@ -6,6 +6,7 @@
 </div>
 
 <% if @materials.any? %>
+  <p class="text-sm text-gray-500 text-right mb-2"><%= pagy_info_text(@pagy) %></p>
   <div class="bg-white rounded-xl shadow-sm overflow-hidden">
     <table class="w-full">
       <thead class="bg-gray-100">
@@ -61,6 +62,9 @@
       </tbody>
     </table>
   </div>
+  <% if @pagy.last > 1 %>
+    <%== @pagy.series_nav %>
+  <% end %>
 <% else %>
   <div class="bg-white rounded-xl shadow-sm p-8 text-center">
     <p class="text-gray-500 mb-4">原材料がまだ登録されていません</p>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -6,6 +6,7 @@
 </div>
 
 <% if @products.any? %>
+  <p class="text-sm text-gray-500 text-right mb-2"><%= pagy_info_text(@pagy) %></p>
   <div class="bg-white rounded-xl shadow-sm overflow-hidden">
     <table class="w-full">
       <thead class="bg-gray-100">
@@ -56,6 +57,9 @@
       </tbody>
     </table>
   </div>
+  <% if @pagy.last > 1 %>
+    <%== @pagy.series_nav %>
+  <% end %>
 <% else %>
   <div class="bg-white rounded-xl shadow-sm p-8 text-center">
     <p class="text-gray-500 mb-4">商品がまだ登録されていません</p>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,3 @@
+Pagy::OPTIONS[:limit] = 20
+Pagy::OPTIONS[:locale] = "ja"
+Pagy::OPTIONS[:raise_range_error] = true

--- a/spec/requests/materials_spec.rb
+++ b/spec/requests/materials_spec.rb
@@ -53,6 +53,41 @@ RSpec.describe "Materials", type: :request do
       expect(response.body).to include("薄力粉")
       expect(response.body).not_to include("他人の材料")
     end
+
+    describe "ページネーション" do
+      before { create_list(:material, 21, user: user) }
+
+      it "件数情報が表示される" do
+        get materials_path
+
+        expect(response.body).to include("全21件中")
+      end
+
+      it "20件を超えるとページネーションが表示される" do
+        get materials_path
+
+        expect(response.body).to include("?page=2")
+      end
+
+      it "2ページ目にアクセスできる" do
+        get materials_path, params: { page: 2 }
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "存在しないページ番号は1ページ目にリダイレクトされる" do
+        get materials_path, params: { page: 999 }
+
+        expect(response).to redirect_to(materials_path)
+      end
+    end
+
+    it "20件以下ではページネーションが表示されない" do
+      create(:material, user: user)
+      get materials_path
+
+      expect(response.body).not_to include("?page=2")
+    end
   end
 
   describe "GET /materials/new" do

--- a/spec/requests/products_spec.rb
+++ b/spec/requests/products_spec.rb
@@ -78,6 +78,41 @@ RSpec.describe "Products", type: :request do
 
       expect(response.body).to include("卵")
     end
+
+    describe "ページネーション" do
+      before { create_list(:product, 21, user: user) }
+
+      it "件数情報が表示される" do
+        get products_path
+
+        expect(response.body).to include("全21件中")
+      end
+
+      it "20件を超えるとページネーションが表示される" do
+        get products_path
+
+        expect(response.body).to include("?page=2")
+      end
+
+      it "2ページ目にアクセスできる" do
+        get products_path, params: { page: 2 }
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "存在しないページ番号は1ページ目にリダイレクトされる" do
+        get products_path, params: { page: 999 }
+
+        expect(response).to redirect_to(products_path)
+      end
+    end
+
+    it "20件以下ではページネーションが表示されない" do
+      create(:product, user: user)
+      get products_path
+
+      expect(response.body).not_to include("?page=2")
+    end
   end
 
   describe "GET /products/new" do


### PR DESCRIPTION
## 背景
原材料・商品の件数が増えると一覧画面の表示が長くなり、目的のデータを探しにくかった。
Pagy gemを使ったページネーションを導入し、1ページ20件ずつ表示するようにした。

## やったこと
- Pagy gemの追加と初期設定（1ページ20件、日本語ロケール）
- ApplicationControllerにPagy::Methodのincludeと不正ページ番号のリダイレクト処理を追加
- 原材料・商品一覧コントローラーにpagy呼び出しを追加
- 件数情報テキスト（「全N件中 X〜Y件を表示」）のヘルパーを追加
- 一覧ビューにページネーションナビゲーションと件数情報を表示
- ページネーションのスタイルをCSSで追加
- ページネーションのリクエストスペックを追加

## 確認方法
- [x] 原材料一覧で20件を超えるとページネーションが表示されること
- [x] 商品一覧で20件を超えるとページネーションが表示されること
- [x] 20件以下ではページネーションが表示されないこと
- [x] 件数情報（「全N件中 X〜Y件を表示」）が正しく表示されること
- [x] 2ページ目以降にアクセスできること
- [x] 存在しないページ番号は1ページ目にリダイレクトされること
- [x] `bundle exec rspec` 全テスト通過（61 examples, 0 failures）

## 関連Issue
Closes #51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pagination added to materials and products lists with 20 items per page.
  * Pagination controls displayed above and below list tables when results exceed one page.
  * Total item count displayed in Japanese format (e.g., "全X件中 Y〜Z件を表示").
  * Invalid page requests redirect to the first page.

* **Tests**
  * Added pagination behavior verification tests.

* **Chores**
  * Updated linting configuration for code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->